### PR TITLE
Update `Cthon` to version `0.29.27`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.29.25" %}
+{% set version = "0.29.27" %}
 
 package:
   name: cython
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/C/Cython/Cython-{{ version }}.tar.gz
-  sha256: a87cbe3756e7c464acf3e9420d8741e62d3b2eace0846cb39f664ad378aab284
+  sha256: c6a442504db906dfc13a480e96850cced994ecdc076bcf492c43515b78f70da2
   patches:
     # xref: https://github.com/cython/cython/pull/4236
     - patches/pypy37-eval.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,21 +34,25 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
   commands:
+    - pip check
     - cython --version
   files:
     - fib.pyx
 
 about:
-  home: http://www.cython.org/
+  home: https://cython.org/
   license: Apache-2.0
   license_file: LICENSE.txt
+  license_family: Apache
   summary: The Cython compiler for writing C extensions for the Python language
   description: |
     Cython is an optimising static compiler for both the Python programming
     language and the extended Cython programming language. It makes writing C
     extensions for Python as easy as Python itself.
-  doc_url: http://cython.org/#documentation
+  doc_url: https://cython.org/#documentation
   dev_url: https://github.com/cython/cython
 
 extra:


### PR DESCRIPTION
  `cython` version `0.29.27`
1. - [x] check the upstream
    https://github.com/cython/cython/tree/0.29.27

2. - [x] check the pinnings

https://github.com/cython/cython/blob/0.29.27/setup.py
https://github.com/cython/cython/blob/0.29.27/doc-requirements.txt

3. - [x] check the changelogs

https://github.com/cython/cython/blob/0.29.27/CHANGES.rst

most of the changes were bug fixes and new features

4. - [] additional research
    https://github.com/conda-forge/cython-feedstock/issues

    There is one open issue mentioned in `Conda-Forge`

5. - [x] verify dev_url
    https://github.com/cython/cython

6. - [x] verify doc_url
    http://cython.org/#documentation

7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number
    The build number is set to zero
10. - [x] verify setuptools
11. - [x] verify wheel
12. - [x] pip in the test section
13. - [x] veriy the test section

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `cython` to version `0.29.27`

