### PR TITLE
cython 0.29.30

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cython" %}
-{% set version = "0.29.28" %}
+{% set version = "0.29.30" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/C/Cython/Cython-{{ version }}.tar.gz
-  sha256: d6fac2342802c30e51426828fe084ff4deb1b3387367cf98976bb2e64b6f8e45
+  sha256: 2235b62da8fe6fa8b99422c8e583f2fb95e143867d337b5c75e4b9a1a865f9e3
 
 build:
   number: 0


### PR DESCRIPTION
Update cython to 0.29.30

`pandas 1.4.3` requires `cython 0.29.30,` see https://github.com/pandas-dev/pandas/blob/e8093ba372f9adfe79439d90fe74b0b5b6dea9d6/setup.py#L41

Bug tracker: https://github.com/conda-forge/cython-feedstock/issues
License: https://github.com/cython/cython/blob/0.29.30/LICENSE.txt
Changelog: https://github.com/cython/cython/blob/0.29.30/CHANGES.rst

Upstream requirements: https://github.com/cython/cython/blob/0.29.30/setup.py

No actions