### PR TITLE
v0.29.33

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cython" %}
-{% set version = "0.29.32" %}
+{% set version = "0.29.33" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/C/Cython/Cython-{{ version }}.tar.gz
-  sha256: 8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7
+  sha256: 5040764c4a4d2ce964a395da24f0d1ae58144995dab92c6b96f44c3f4d72286a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,21 +30,6 @@ requirements:
     - python
 
 test:
-  imports:
-    - Cython
-    - Cython.Build
-    - Cython.Compiler
-    - Cython.Runtime
-    - Cython.Distutils
-    - Cython.Debugger
-    - Cython.Debugger.Tests
-    - Cython.Plex
-    - Cython.Tests
-    - Cython.Build.Tests
-    - Cython.Compiler.Tests
-    - Cython.Utility
-    - Cython.Tempita
-    - pyximport
   requires:
     - pip
   commands:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -2,6 +2,8 @@ import platform
 is_cpython = platform.python_implementation() == 'CPython'
 
 import Cython
+import Cython.Build
+import Cython.Compiler
 import Cython.Compiler.Code
 import Cython.Compiler.FlowControl
 import Cython.Compiler.Lexicon
@@ -10,6 +12,17 @@ import Cython.Compiler.Scanning
 import Cython.Compiler.Visitor
 import Cython.Plex.Actions
 import Cython.Plex.Scanners
+import Cython.Runtime
+import Cython.Distutils
+import Cython.Debugger
+import Cython.Debugger.Tests
+import Cython.Plex
+import Cython.Tests
+import Cython.Build.Tests
+import Cython.Compiler.Tests
+import Cython.Utility
+import Cython.Tempita
+import pyximport
 
 if is_cpython:
     import Cython.Runtime.refnanny


### PR DESCRIPTION
# cython 0.29.33

upstream: https://github.com/cython/cython/tree/0.29.33
jira: https://anaconda.atlassian.net/browse/PKG-1155

## Changes
- Bump version and SHA
- Move import tests to `run_test.py` since they aren't both executed

## Notes
- This is needed to update `scikit-learn` for python 3.11 support