### PR TITLE
cython 3.0.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,7 @@ test:
     - fib.pyx
   requires:
     - pip
-    # for distutils
-    - setuptools  # [py>=312]
-    - setuptools <60  # [py<312]
+    - setuptools
     - {{ compiler('c') }}
     # for runtests.py
     #- numpy
@@ -49,7 +47,7 @@ test:
     # 2023/12/19: The upstream test suite is quite slow.
     # It requires files: `runtests.py`, the folder `tests/`, and dependencies: setuptools, numpy and pythran (optionally).
     # If you want to run refnanny tests then add to source_files `Cython/Runtime/refnanny.pyx` and remove --no-refnanny flag.
-    #- python runtests.py -v --no-doctest --no-pyregr --no-code-style --no-refnanny --no-annotate
+    #- python runtests.py -v --no-doctest --no-pyregr --no-code-style --no-refnanny --annotate
     # source_files:
     #   - runtests.py
     #   - tests/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,26 +29,30 @@ requirements:
     - python
 
 test:
-  source_files:
-    - runtests.py
-    - tests/
   files:
     - fib.pyx
   requires:
-    - {{ compiler('c') }}
-    - numpy
     - pip
-    - pythran
     # for distutils
     - setuptools  # [py>=312]
     - setuptools <60  # [py<312]
+    - {{ compiler('c') }}
+    # for runtests.py
+    #- numpy
+    #- pythran
   commands:
     - pip check
     - cython --version
     - cython --help
     - cythonize --help
     - cygdb --help
-    - python runtests.py -v --no-doctest --no-pyregr --no-code-style --no-refnanny --no-annotate
+    # 2023/12/19: The upstream test suite is quite slow.
+    # It requires files: `runtests.py`, the folder `tests/`, and dependencies: setuptools, numpy and pythran (optionally).
+    # If you want to run refnanny tests then add to source_files `Cython/Runtime/refnanny.pyx` and remove --no-refnanny flag.
+    #- python runtests.py -v --no-doctest --no-pyregr --no-code-style --no-refnanny --no-annotate
+    # source_files:
+    #   - runtests.py
+    #   - tests/
 
 about:
   home: https://cython.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cython" %}
-{% set version = "3.0.0" %}
+{% set version = "3.0.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Cython-{{ version }}.tar.gz
-  sha256: 350b18f9673e63101dbbfcf774ee2f57c20ac4636d255741d76ca79016b1bd82
+  sha256: 399d185672c667b26eabbdca420c98564583798af3bc47670a8a09e9f19dd660
 
 build:
   number: 0
@@ -29,16 +29,18 @@ requirements:
     - python
 
 test:
+  files:
+    - fib.pyx
   requires:
     - pip
+    # for distutils
+    - setuptools  # [py>=312]
   commands:
     - pip check
     - cython --version
     - cython --help
     - cythonize --help
     - cygdb --help
-  files:
-    - fib.pyx
 
 about:
   home: https://cython.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,18 +29,26 @@ requirements:
     - python
 
 test:
+  source_files:
+    - runtests.py
+    - tests/
   files:
     - fib.pyx
   requires:
+    - {{ compiler('c') }}
+    - numpy
     - pip
+    - pythran
     # for distutils
     - setuptools  # [py>=312]
+    - setuptools <60  # [py<312]
   commands:
     - pip check
     - cython --version
     - cython --help
     - cythonize --help
     - cygdb --help
+    - python runtests.py -v --no-doctest --no-pyregr --no-code-style --no-refnanny --no-annotate
 
 about:
   home: https://cython.org/

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -23,9 +23,8 @@ import Cython.Build.Tests
 import Cython.Compiler.Tests
 import Cython.Utility
 import Cython.Tempita
-# See: https://github.com/cython/cython/issues/5285#issuecomment-1455043943
-if sys.version_info < (3, 12):
-    import pyximport
+
+import pyximport
 
 if is_cpython:
     import Cython.Runtime.refnanny
@@ -34,24 +33,26 @@ import sys
 import os
 import subprocess
 from pprint import pprint
-from os.path import isfile
 
-print('sys.executable: %r' % sys.executable)
-print('sys.prefix: %r' % sys.prefix)
-print('sys.version: %r' % sys.version)
-print('PATH: %r' % os.environ['PATH'])
-print('CWD: %r' % os.getcwd())
+pprint('sys.executable: %r' % sys.executable)
+pprint('sys.prefix: %r' % sys.prefix)
+pprint('sys.version: %r' % sys.version)
+pprint('PATH: %r' % os.environ['PATH'])
+pprint('CWD: %r' % os.getcwd())
 
-from distutils.spawn import find_executable
-from distutils.core import setup
-from distutils.extension import Extension
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 from Cython.Distutils import build_ext
+from shutil import which as find_executable
 
-if sys.platform != 'darwin' and find_executable('gcc'):
+
+if find_executable('gcc') or find_executable('clang'):
     sys.argv[1:] = ['build_ext', '--inplace']
     setup(name='fib',
-          cmdclass={'build_ext': build_ext},
-          ext_modules=[Extension("fib", ["fib.pyx"])])
+        cmdclass={'build_ext': build_ext},
+        ext_modules=[Extension("fib", ["fib.pyx"])])
 
     try:
         import fib

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -40,10 +40,7 @@ pprint('sys.version: %r' % sys.version)
 pprint('PATH: %r' % os.environ['PATH'])
 pprint('CWD: %r' % os.getcwd())
 
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from Cython.Distutils import build_ext
 from shutil import which as find_executable
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3683](https://anaconda.atlassian.net/browse/PKG-3683) 
- [Upstream repository](https://github.com/cython/cython/tree/3.0.6)
- Upstream requirements: 
  - https://github.com/cython/cython/blob/3.0.6/setup.py

### Explanation of changes:

- Add `setuptools  # [py>=312]` as a test dependency for `distutils`

### Notes:

- gevent 23.9.1 requires cython >=3.0.2 https://github.com/AnacondaRecipes/gevent-feedstock/pull/5

[PKG-3683]: https://anaconda.atlassian.net/browse/PKG-3683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ