### PR TITLE
Version 3.0.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cython" %}
-{% set version = "3.0.5" %}
+{% set version = "3.0.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Cython-{{ version }}.tar.gz
-  sha256: 39318348db488a2f24e7c84e08bdc82f2624853c0fea8b475ea0b70b27176492
+  sha256: 8333423d8fd5765e7cceea3a9985dd1e0a5dfeb2734629e1a2ed2d6233d39de6
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cython" %}
-{% set version = "3.0.6" %}
+{% set version = "3.0.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Cython-{{ version }}.tar.gz
-  sha256: 399d185672c667b26eabbdca420c98564583798af3bc47670a8a09e9f19dd660
+  sha256: 39318348db488a2f24e7c84e08bdc82f2624853c0fea8b475ea0b70b27176492
 
 build:
   number: 0


### PR DESCRIPTION
cython 3.0.8 (for pandas 2.2.0)

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/cython/cython/tree/3.0.5)
- [Upstream changelog/diff](https://github.com/cython/cython/blob/3.0.5/CHANGES.rst)
- Relevant dependency PRs:
  - https://github.com/pandas-dev/pandas/tree/v2.2.0

### Explanation of changes:

- Change version to `3.0.8`
