### PR TITLE
cython 0.29.37

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cython" %}
-{% set version = "0.29.36" %}
+{% set version = "0.29.37" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Cython-{{ version }}.tar.gz
-  sha256: 41c0cfd2d754e383c9eeb95effc9aa4ab847d0c9747077ddd7c0dcb68c3bc01f
+  sha256: f813d4a6dd94adee5d4ff266191d1d95bf6d4164a4facc535422c021b2504cfb
 
 build:
   number: 0

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -50,8 +50,8 @@ from Cython.Distutils import build_ext
 if sys.platform != 'darwin' and find_executable('gcc'):
     sys.argv[1:] = ['build_ext', '--inplace']
     setup(name='fib',
-          cmdclass={'build_ext': build_ext},
-          ext_modules=[Extension("fib", ["fib.pyx"])])
+        cmdclass={'build_ext': build_ext},
+        ext_modules=[Extension("fib", ["fib.pyx"])])
 
     try:
         import fib


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5912](https://anaconda.atlassian.net/browse/PKG-5912) 
- [Upstream repository](https://github.com/cython/cython/tree/0.29.37)
- Requirements: https://github.com/cython/cython/blob/0.29.37/setup.py

### Explanation of changes:

- Fix indentation

### Notes:

- It's needed to fix a bug in v0.29.36, see https://github.com/AnacondaRecipes/spacy-feedstock/pull/26#issuecomment-2402609435

[PKG-5912]: https://anaconda.atlassian.net/browse/PKG-5912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ