### PR TITLE
PKG-7247: enable py313

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/0001-fix-_PyLong_AsByteArray.patch
+++ b/recipe/0001-fix-_PyLong_AsByteArray.patch
@@ -1,0 +1,29 @@
+From 3e9cf61eeb953babc16ffbe98e47b1324cc1eabd Mon Sep 17 00:00:00 2001
+From: Andrii Osipov <aosipov@anaconda.com>
+Date: Wed, 26 Feb 2025 13:49:36 -0800
+Subject: [PATCH] fix _PyLong_AsByteArray
+
+---
+ Cython/Utility/TypeConversion.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/Cython/Utility/TypeConversion.c b/Cython/Utility/TypeConversion.c
+index 4048149..46e74a7 100644
+--- a/Cython/Utility/TypeConversion.c
++++ b/Cython/Utility/TypeConversion.c
+@@ -988,7 +988,11 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
+                 unsigned char *bytes = (unsigned char *)&val;
+                 int ret = _PyLong_AsByteArray((PyLongObject *)v,
+                                               bytes, sizeof(val),
+-                                              is_little, !is_unsigned);
++                                              is_little, !is_unsigned
++#if PY_VERSION_HEX >= 0x030d00a4
++                                              , 1 // with_exceptions
++#endif              
++                                              );
+                 Py_DECREF(v);
+                 if (likely(!ret))
+                     return val;
+-- 
+2.39.3 (Apple Git-146)
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Cython-{{ version }}.tar.gz
   sha256: f813d4a6dd94adee5d4ff266191d1d95bf6d4164a4facc535422c021b2504cfb
+  patches:
+    - 0001-fix-_PyLong_AsByteArray.patch
 
 build:
   number: 1
@@ -19,6 +21,8 @@ build:
 
 requirements:
   build:
+    - patch  # [not win]
+    - m2-patch  # [win]
     - {{ compiler('c') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f813d4a6dd94adee5d4ff266191d1d95bf6d4164a4facc535422c021b2504cfb
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - cython = Cython.Compiler.Main:setuptools_main


### PR DESCRIPTION
cython 0.29.37 

**Destination channel:** defaults

### Links

- [PKG-7247](https://anaconda.atlassian.net/browse/PKG-7247)

### Explanation of changes:

- enable py313


[PKG-7247]: https://anaconda.atlassian.net/browse/PKG-7247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ