### PR TITLE
cython 3.0.12 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,22 @@
 {% set name = "cython" %}
-{% set version = "3.0.11" %}
+{% set version = "3.0.12" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cython-{{ version }}.tar.gz
-  sha256: 7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b988bb297ce76c671e28c97d017b95411010f7c77fa6623dd0bb47eed1aee1bc
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - cython = Cython.Compiler.Main:setuptools_main
     - cythonize = Cython.Build.Cythonize:main
     - cygdb = Cython.Debugger.Cygdb:main
+  skip: true  # [py<34]
 
 requirements:
   build:
@@ -31,6 +32,9 @@ requirements:
 test:
   files:
     - fib.pyx
+  imports:
+    - Cython
+    - pyximport
   requires:
     - pip
     - setuptools
@@ -53,7 +57,7 @@ test:
     #   - tests/
 
 about:
-  home: https://cython.org/
+  home: https://cython.org
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE.txt
@@ -62,7 +66,7 @@ about:
     Cython is an optimising static compiler for both the Python programming
     language and the extended Cython programming language. It makes writing C
     extensions for Python as easy as Python itself.
-  doc_url: https://cython.readthedocs.io/
+  doc_url: https://cython.readthedocs.io
   dev_url: https://github.com/cython/cython
 
 extra:


### PR DESCRIPTION
cython 3.0.12 

**Destination channel:** Defaults

### Links

- [PKG-8738]
- dev_url:        https://github.com/cython/cython/tree/3.0.12
- conda_forge:    https://github.com/conda-forge/cython-feedstock
- pypi:           https://pypi.org/project/cython/3.0.12
- pypi inspector: https://inspector.pypi.io/project/cython/3.0.12

### Explanation of changes:

- new version number


[PKG-8738]: https://anaconda.atlassian.net/browse/PKG-8738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ