### PR TITLE
[PKG-9810] 3.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cython" %}
-{% set version = "3.1.3" %}
+{% set version = "3.1.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 10ee785e42328924b78f75a74f66a813cb956b4a9bc91c44816d089d5934c089
+  sha256: 9aefefe831331e2d66ab31799814eae4d0f8a2d246cbaaaa14d1be29ef777683
 
 build:
   number: 0


### PR DESCRIPTION
cython 3.1.4

**Destination channel:** defaults

### Links

- [PKG-9810] 
- [Upstream repository](https://github.com/cython/cython)

### Explanation of changes:

- Simple version bump
- Tried to run upstream tests locally, but they take hours to run.


[PKG-9810]: https://anaconda.atlassian.net/browse/PKG-9810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ